### PR TITLE
Fix pipeline hang issue on deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,4 +31,4 @@ deploy:
   script:
     - echo "Deploying Node.js app to App Server"
     - scp -o StrictHostKeyChecking=no -r sample-apps/node-app/* ubuntu@18.134.245.3:/var/www/node-app/
-    - ssh ubuntu@18.134.245.3 "cd /var/www/node-app && npm install && nohup node app.js > /dev/null 2>&1 &"
+    - ssh ubuntu@18.134.245.3 "cd /var/www/node-app && npm install && nohup node app.js </dev/null >/dev/null 2>&1 &"

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
                 sh '''
                 echo "Deploying Python app to App Server"
                 scp -o StrictHostKeyChecking=no -r sample-apps/python-app/* ubuntu@18.134.245.3:/var/www/python-app/
-                ssh -o StrictHostKeyChecking=no ubuntu@18.134.245.3 "cd /var/www/python-app && pip install -r requirements.txt --break-system-packages && nohup python3 app.py > /dev/null 2>&1 &"
+                ssh -o StrictHostKeyChecking=no ubuntu@18.134.245.3 "cd /var/www/python-app && pip install -r requirements.txt --break-system-packages && nohup python3 app.py </dev/null >/dev/null 2>&1 &"
                 '''
             }
         }


### PR DESCRIPTION
- Add stdin redirect to prevent SSH hanging
- Redirect to /dev/null for proper background execution
- Pipelines will now complete after deployment